### PR TITLE
remove "=" after arguments

### DIFF
--- a/gatk4-rna-best-practices.wdl
+++ b/gatk4-rna-best-practices.wdl
@@ -266,9 +266,9 @@ task gtfToCallingIntervals {
 
         ${gatk_path} \
             BedToIntervalList \
-            -I=exome.fixed.bed \
-            -O=${output_name} \
-            -SD=${ref_dict}
+            -I exome.fixed.bed \
+            -O ${output_name} \
+            -SD ${ref_dict}
     >>>
 
     output {
@@ -718,7 +718,7 @@ task MergeVCFs {
     command <<<
         ${gatk_path} --java-options "-Xms2000m"  \
             MergeVcfs \
-            --INPUT ${sep=' --INPUT=' input_vcfs} \
+            --INPUT ${sep=' --INPUT ' input_vcfs} \
             --OUTPUT ${output_vcf_name}
     >>>
 
@@ -748,12 +748,12 @@ task ScatterIntervalList {
         mkdir out
         ${gatk_path} --java-options "-Xms1g" \
             IntervalListTools \
-            --SCATTER_COUNT=${scatter_count} \
-            --SUBDIVISION_MODE=BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW \
-            --UNIQUE=true \
-            --SORT=true \
-            --INPUT=${interval_list} \
-            --OUTPUT=out
+            --SCATTER_COUNT ${scatter_count} \
+            --SUBDIVISION_MODE BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW \
+            --UNIQUE true \
+            --SORT true \
+            --INPUT ${interval_list} \
+            --OUTPUT out
 	
         python3 <<CODE
         import glob, os


### PR DESCRIPTION
It looks like in the `.wdl` file some lines retained gatk3 arguments instead of those for gatk4. Say in line 269, I think gatk4 uses `-I exome.fixed.bed` but not `-I=exome.fixed.bed`. After making the changes, it worked locally for me. I use gatk-4.1.8.0 on a Ubuntu machine.