### PR TITLE
Error when interval list is empty and remove PairedRun from MBA

### DIFF
--- a/gatk4-rna-best-practices.wdl
+++ b/gatk4-rna-best-practices.wdl
@@ -439,7 +439,6 @@ task MergeBamAlignment {
             --ALIGNED_BAM ${star_bam} \
             --OUTPUT ${base_name}.bam \
             --INCLUDE_SECONDARY_ALIGNMENTS false \
-            --PAIRED_RUN False \
             --VALIDATION_STRINGENCY SILENT
     >>>
  

--- a/gatk4-rna-best-practices.wdl
+++ b/gatk4-rna-best-practices.wdl
@@ -764,6 +764,8 @@ task ScatterIntervalList {
           newName = os.path.join(directory, str(i + 1) + filename)
           os.rename(interval, newName)
         print(len(intervals))
+        if len(intervals) == 0:
+          raise ValueError("Interval list produced 0 scattered interval lists. Is the gtf or input interval list empty?")
         f = open("interval_count.txt", "w+")
         f.write(str(len(intervals)))
         f.close()


### PR DESCRIPTION
This will now throw an error in the ScatterIntervalList task when 0 interval lists are produced. Also removed the PairedRun arg from MergeBamAlignment.

I'm running the example inputs now and it made it past ScatterIntervalList correctly, but the rest of the pipeline is still running. Also I ran it on an empty input gtf to confirm the error is thrown at ScatterIntervalList.
